### PR TITLE
doc: add hal cmd Example

### DIFF
--- a/cli-reference.adoc
+++ b/cli-reference.adoc
@@ -6,10 +6,11 @@ ___________________
 
 [source,sh]
 ----
- 
+  # Displays hal help
+  hal  --help 
 ----
 
-hal v0.1.5-6-gae39d85 built with ❤️ by the Snowdrop team on 'Thu Sep 12 12:46:12 CEST 2019' (commit: ae39d85) running on top of 'oc'
+hal v0.1.5-10-g8ec1839 built with ❤️ by the Snowdrop team on 'Fri Sep 13 12:41:17 CEST 2019' (commit: 8ec1839) running on top of 'oc'
 Easily create and manage Kubernetes applications using Dekorate and the Halkyon operator.
 
 [[syntax]]

--- a/pkg/hal/cli/hal.go
+++ b/pkg/hal/cli/hal.go
@@ -7,9 +7,15 @@ import (
 	"halkyon.io/hal/pkg/hal/cli/component"
 	"halkyon.io/hal/pkg/hal/cli/link"
 	"halkyon.io/hal/pkg/hal/cli/version"
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
 
 const commandName = "hal"
+
+var (
+	halExample = ktemplates.Examples(`  # Displays hal help
+ %[1]s  --help`)
+)
 
 func NewCmdHal() *cobra.Command {
 	hal := &cobra.Command{
@@ -17,6 +23,7 @@ func NewCmdHal() *cobra.Command {
 		Short: "Easily create Kubernetes applications",
 		Long: fmt.Sprintf(`%s
 Easily create and manage Kubernetes applications using Dekorate and the Halkyon operator.`, version.Version()),
+		Example: fmt.Sprintf(halExample, commandName),
 	}
 
 	hal.AddCommand(


### PR DESCRIPTION
While looking at the readm for adding the link to the cli reference I saw tha `hal` hadn't Example so I added it.