### PR TITLE
Add delete commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,3 +29,5 @@ replace (
 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.0.0-20190516231937-17bc0b7fcef5
 	k8s.io/client-go => k8s.io/client-go v11.0.1-0.20190516230509-ae8359b20417+incompatible
 )
+
+go 1.13

--- a/pkg/cmdutil/delete.go
+++ b/pkg/cmdutil/delete.go
@@ -1,0 +1,95 @@
+package cmdutil
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"halkyon.io/hal/pkg/log"
+	"halkyon.io/hal/pkg/ui"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record/util"
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
+)
+
+const deleteCommandName = "delete"
+
+type DeleteOptions struct {
+	ResourceType string
+	Name         string
+	Client       HalkyonEntity
+}
+
+type HalkyonEntity interface {
+	Get(string, v1.GetOptions) error
+	Delete(string, *v1.DeleteOptions) error
+	GetKnown() []string
+	GetNamespace() string
+}
+
+var (
+	Example = ktemplates.Examples(`  # Delete the %[2]s named 'foo'
+  %[1]s foo`)
+)
+
+func (o *DeleteOptions) Complete(name string, cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		o.Name = ""
+	} else {
+		o.Name = args[0]
+	}
+
+	return nil
+}
+
+func (o *DeleteOptions) Validate() error {
+	needName := len(o.Name) == 0
+	if !needName {
+		err := o.Client.Get(o.Name, v1.GetOptions{})
+		if err != nil {
+			if util.IsKeyNotFoundError(errors.Cause(err)) {
+				needName = true
+			} else {
+				return err
+			}
+		}
+	}
+	if needName {
+		known := o.Client.GetKnown()
+		if len(known) == 0 {
+			return fmt.Errorf("no %s currently exist in '%s'", o.ResourceType, o.Client.GetNamespace())
+		}
+		s := "Unknown " + o.ResourceType
+		if len(o.Name) == 0 {
+			s = "No provided " + o.ResourceType + " name"
+		}
+		message := ui.SelectFromOtherErrorMessage(s, o.Name)
+		o.Name = ui.Select(message, known)
+	}
+	return nil
+}
+
+func (o *DeleteOptions) Run() error {
+	if ui.Proceed(fmt.Sprintf("Really delete '%s' %s", o.Name, o.ResourceType)) {
+		err := o.Client.Delete(o.Name, &v1.DeleteOptions{})
+		if err == nil {
+			log.Successf("Successfully deleted '%s' %s", o.Name, o.ResourceType)
+		}
+		return err
+	}
+	log.Errorf("Canceled deletion of '%s' %s", o.Name, o.ResourceType)
+	return nil
+}
+
+func NewGenericDelete(fullParentName string, o *DeleteOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     fmt.Sprintf("%s <name of %s to delete>", deleteCommandName, o.ResourceType),
+		Short:   fmt.Sprintf("Delete the named %s", o.ResourceType),
+		Long:    fmt.Sprintf("Delete the named %s if it exists", o.ResourceType),
+		Example: fmt.Sprintf(Example, CommandName(deleteCommandName, fullParentName), o.ResourceType),
+		Args:    cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			GenericRun(o, cmd, args)
+		},
+	}
+	return cmd
+}

--- a/pkg/hal/cli/capability/capability.go
+++ b/pkg/hal/cli/capability/capability.go
@@ -3,244 +3,25 @@ package capability
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"gopkg.in/AlecAivazis/survey.v1"
-	"halkyon.io/api/capability/v1beta1"
-	halkyon "halkyon.io/api/v1beta1"
 	"halkyon.io/hal/pkg/cmdutil"
-	"halkyon.io/hal/pkg/k8s"
-	"halkyon.io/hal/pkg/log"
-	"halkyon.io/hal/pkg/ui"
-	"halkyon.io/hal/pkg/validation"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ktemplates "k8s.io/kubectl/pkg/util/templates"
-	"strings"
-	"time"
 )
 
-const capabilityCommandName = "capability"
-
-type capabilityOptions struct {
-	category    string
-	subCategory string
-	version     string
-	paramPairs  []string
-	parameters  []halkyon.NameValuePair
-	name        string
-}
-
-var (
-	capabilityExample = ktemplates.Examples(`  # Create a new database capability de type postgres 10 and sets up some parameters as the name of the database and the user/password to connect.
-  %[1]s -n db-capability -g database -t postgres -v 10 -p DB_NAME=sample-db -p DB_PASSWORD=admin -p DB_USER=admin`)
-)
-
-func (o *capabilityOptions) Complete(name string, cmd *cobra.Command, args []string) error {
-	o.selectOrCheckExisting(&o.category, "Category", o.getCategories(), o.isValidCategory)
-	o.selectOrCheckExisting(&o.subCategory, "Type", o.getTypesFor(o.category), o.isValidTypeGivenCategory)
-	o.selectOrCheckExisting(&o.version, "Version", o.getVersionsFor(o.category, o.subCategory), o.isValidVersionGivenCategoryAndType)
-
-	for _, pair := range o.paramPairs {
-		if e := o.addToParams(pair); e != nil {
-			return e
-		}
-	}
-
-	generated := fmt.Sprintf("%s-capability-%d", o.subCategory, time.Now().UnixNano())
-	o.name = ui.Ask("Name", o.name, generated)
-
-	return nil
-}
-
-func (o *capabilityOptions) Validate() error {
-	infos := o.getParameterInfos()
-
-	params := make(map[string]parameterInfo, len(infos))
-	for _, v := range infos {
-		params[v.name] = v
-	}
-
-	o.parameters = make([]halkyon.NameValuePair, 0, len(params))
-
-	// first deal with required params
-	for _, info := range infos {
-		if info.Required {
-			o.addValueFor(info)
-			// remove property from list of properties to consider
-			delete(params, info.name)
-		}
-	}
-
-	// finally check if we still have capability parameters that have not been considered
-	if len(params) > 0 && ui.Proceed("Provide values for non-required parameters") {
-		for _, prop := range params {
-			o.addValueFor(prop)
-		}
-	}
-
-	return nil
-}
-
-type parameterInfo struct {
-	validation.Validatable
-	name string
-}
-
-func (p parameterInfo) AsValidatable() validation.Validatable {
-	return p.Validatable
-}
-
-func (o *capabilityOptions) Run() error {
-	client := k8s.GetClient()
-	c, err := client.HalkyonCapabilityClient.Capabilities(client.Namespace).Create(&v1beta1.Capability{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      o.name,
-			Namespace: client.Namespace,
-		},
-		Spec: v1beta1.CapabilitySpec{
-			Category:   v1beta1.DatabaseCategory, // todo: replace hardcoded value
-			Type:       v1beta1.PostgresType,     // todo: replace hardcoded value
-			Version:    o.version,
-			Parameters: o.parameters,
-		},
-	})
-
-	if err != nil {
-		return err
-	}
-
-	log.Successf("Created capability %s", c.Name)
-
-	return nil
-}
-
-func (o *capabilityOptions) selectOrCheckExisting(parameterValue *string, capitalizedParameterName string, validValues []string, validator func() bool) {
-	if len(*parameterValue) == 0 {
-		*parameterValue = ui.Select(capitalizedParameterName, validValues)
-	} else {
-		lowerCaseParameterName := strings.ToLower(capitalizedParameterName)
-		if !validator() {
-			s := ui.SelectFromOtherErrorMessage("Unknown "+lowerCaseParameterName, *parameterValue)
-			ui.Select(s, validValues)
-		} else {
-			ui.OutputSelection("Selected "+lowerCaseParameterName, *parameterValue)
-		}
-	}
-}
-
-func (o *capabilityOptions) getCategories() []string {
-	// todo: implement operator querying of available capabilities
-	return []string{"database"}
-}
-
-func (o *capabilityOptions) isValidCategory() bool {
-	return isValid(o.category, o.getCategories())
-}
-
-func isValid(value string, validValues []string) bool {
-	for _, v := range validValues {
-		if value == v {
-			return true
-		}
-	}
-	return false
-}
-
-func (o *capabilityOptions) getTypesFor(category string) []string {
-	// todo: implement operator querying for available types for given category
-	return []string{"postgres"}
-}
-
-func (o *capabilityOptions) isValidTypeGivenCategory() bool {
-	return o.isValidTypeFor(o.category)
-}
-
-func (o *capabilityOptions) isValidTypeFor(category string) bool {
-	return isValid(o.subCategory, o.getTypesFor(category))
-}
-
-func (o *capabilityOptions) getVersionsFor(category, subCategory string) []string {
-	// todo: implement operator querying
-	return []string{"11", "10", "9.6", "9.5", "9.4"}
-}
-
-func (o *capabilityOptions) isValidVersionFor(category, subCategory string) bool {
-	return isValid(o.version, o.getVersionsFor(category, subCategory))
-}
-
-func (o *capabilityOptions) isValidVersionGivenCategoryAndType() bool {
-	return o.isValidVersionFor(o.category, o.subCategory)
-}
-
-func (o *capabilityOptions) addToParams(pair string) error {
-	// todo: extract as generic version to be used for Envs and Parameters
-	split := strings.Split(pair, "=")
-	if len(split) != 2 {
-		return fmt.Errorf("invalid parameter: %s, format must be 'name=value'", pair)
-	}
-	parameter := halkyon.NameValuePair{Name: split[0], Value: split[1]}
-	o.parameters = append(o.parameters, parameter)
-	ui.OutputSelection("Set parameter", fmt.Sprintf("%s=%s", parameter.Name, parameter.Value))
-	return nil
-}
-
-func (o *capabilityOptions) getParameterInfos() []parameterInfo {
-	// todo: implement operator querying
-	infos := make([]parameterInfo, 3, 3)
-	infos[0] = parameterInfo{
-		Validatable: validation.Validatable{
-			Required: true,
-			Type:     "string",
-		},
-		name: "DB_NAME",
-	}
-	infos[1] = parameterInfo{
-		name: "DB_PASSWORD",
-		Validatable: validation.Validatable{
-			Required: true,
-			Type:     "string",
-		},
-	}
-	infos[2] = parameterInfo{
-		name: "DB_USER",
-		Validatable: validation.Validatable{
-			Required: true,
-			Type:     "string",
-		},
-	}
-	return infos
-}
-
-func (o *capabilityOptions) addValueFor(prop parameterInfo) {
-	var result string
-	prompt := &survey.Input{
-		Message: fmt.Sprintf("Enter a value for %s property %s:", prop.Type, prop.name),
-	}
-
-	err := survey.AskOne(prompt, &result, ui.GetValidatorFor(prop.AsValidatable()))
-	ui.HandleError(err)
-	o.parameters = append(o.parameters, halkyon.NameValuePair{
-		Name:  prop.name,
-		Value: result,
-	})
-}
+const commandName = "capability"
 
 func NewCmdCapability(parent string) *cobra.Command {
-	o := &capabilityOptions{}
-	capability := &cobra.Command{
-		Use:     fmt.Sprintf("%s [flags]", capabilityCommandName),
-		Short:   "Create a new capability",
-		Long:    `Create a new capability`,
-		Args:    cobra.NoArgs,
-		Example: fmt.Sprintf(capabilityExample, cmdutil.CommandName(capabilityCommandName, parent)),
-		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.GenericRun(o, cmd, args)
-		},
+	fullName := cmdutil.CommandName(commandName, parent)
+	create := NewCmdCreate(fullName)
+
+	hal := &cobra.Command{
+		Use:     fmt.Sprintf("%s [flags]", commandName),
+		Short:   "Manage capabilities",
+		Long:    `Manage capabilities`,
+		Example: fmt.Sprintf("%s", create.Example),
 	}
 
-	capability.Flags().StringVarP(&o.category, "category", "g", "", "Capability category e.g. 'database'")
-	capability.Flags().StringVarP(&o.name, "name", "n", "", "Capability name")
-	capability.Flags().StringVarP(&o.subCategory, "type", "t", "", "Capability type e.g. 'postgres'")
-	capability.Flags().StringVarP(&o.version, "version", "v", "", "Capability version")
-	capability.Flags().StringSliceVarP(&o.paramPairs, "parameters", "p", []string{}, "Capability-specific parameters")
+	hal.AddCommand(
+		create,
+	)
 
-	return capability
+	return hal
 }

--- a/pkg/hal/cli/capability/capability.go
+++ b/pkg/hal/cli/capability/capability.go
@@ -11,16 +11,18 @@ const commandName = "capability"
 func NewCmdCapability(parent string) *cobra.Command {
 	fullName := cmdutil.CommandName(commandName, parent)
 	create := NewCmdCreate(fullName)
+	del := NewCmdDelete(fullName)
 
 	hal := &cobra.Command{
 		Use:     fmt.Sprintf("%s [flags]", commandName),
 		Short:   "Manage capabilities",
 		Long:    `Manage capabilities`,
-		Example: fmt.Sprintf("%s", create.Example),
+		Example: fmt.Sprintf("%s\n\n%s", create.Example, del.Example),
 	}
 
 	hal.AddCommand(
 		create,
+		del,
 	)
 
 	return hal

--- a/pkg/hal/cli/capability/create.go
+++ b/pkg/hal/cli/capability/create.go
@@ -1,0 +1,246 @@
+package capability
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"gopkg.in/AlecAivazis/survey.v1"
+	"halkyon.io/api/capability/v1beta1"
+	halkyon "halkyon.io/api/v1beta1"
+	"halkyon.io/hal/pkg/cmdutil"
+	"halkyon.io/hal/pkg/k8s"
+	"halkyon.io/hal/pkg/log"
+	"halkyon.io/hal/pkg/ui"
+	"halkyon.io/hal/pkg/validation"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
+	"strings"
+	"time"
+)
+
+const createCommandeName = "create"
+
+type createOptions struct {
+	category    string
+	subCategory string
+	version     string
+	paramPairs  []string
+	parameters  []halkyon.NameValuePair
+	name        string
+}
+
+var (
+	capabilityExample = ktemplates.Examples(`  # Create a new database capability de type postgres 10 and sets up some parameters as the name of the database and the user/password to connect.
+  %[1]s -n db-capability -g database -t postgres -v 10 -p DB_NAME=sample-db -p DB_PASSWORD=admin -p DB_USER=admin`)
+)
+
+func (o *createOptions) Complete(name string, cmd *cobra.Command, args []string) error {
+	o.selectOrCheckExisting(&o.category, "Category", o.getCategories(), o.isValidCategory)
+	o.selectOrCheckExisting(&o.subCategory, "Type", o.getTypesFor(o.category), o.isValidTypeGivenCategory)
+	o.selectOrCheckExisting(&o.version, "Version", o.getVersionsFor(o.category, o.subCategory), o.isValidVersionGivenCategoryAndType)
+
+	for _, pair := range o.paramPairs {
+		if e := o.addToParams(pair); e != nil {
+			return e
+		}
+	}
+
+	generated := fmt.Sprintf("%s-capability-%d", o.subCategory, time.Now().UnixNano())
+	o.name = ui.Ask("Name", o.name, generated)
+
+	return nil
+}
+
+func (o *createOptions) Validate() error {
+	infos := o.getParameterInfos()
+
+	params := make(map[string]parameterInfo, len(infos))
+	for _, v := range infos {
+		params[v.name] = v
+	}
+
+	o.parameters = make([]halkyon.NameValuePair, 0, len(params))
+
+	// first deal with required params
+	for _, info := range infos {
+		if info.Required {
+			o.addValueFor(info)
+			// remove property from list of properties to consider
+			delete(params, info.name)
+		}
+	}
+
+	// finally check if we still have capability parameters that have not been considered
+	if len(params) > 0 && ui.Proceed("Provide values for non-required parameters") {
+		for _, prop := range params {
+			o.addValueFor(prop)
+		}
+	}
+
+	return nil
+}
+
+type parameterInfo struct {
+	validation.Validatable
+	name string
+}
+
+func (p parameterInfo) AsValidatable() validation.Validatable {
+	return p.Validatable
+}
+
+func (o *createOptions) Run() error {
+	client := k8s.GetClient()
+	c, err := client.HalkyonCapabilityClient.Capabilities(client.Namespace).Create(&v1beta1.Capability{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      o.name,
+			Namespace: client.Namespace,
+		},
+		Spec: v1beta1.CapabilitySpec{
+			Category:   v1beta1.DatabaseCategory, // todo: replace hardcoded value
+			Type:       v1beta1.PostgresType,     // todo: replace hardcoded value
+			Version:    o.version,
+			Parameters: o.parameters,
+		},
+	})
+
+	if err != nil {
+		return err
+	}
+
+	log.Successf("Created capability %s", c.Name)
+
+	return nil
+}
+
+func (o *createOptions) selectOrCheckExisting(parameterValue *string, capitalizedParameterName string, validValues []string, validator func() bool) {
+	if len(*parameterValue) == 0 {
+		*parameterValue = ui.Select(capitalizedParameterName, validValues)
+	} else {
+		lowerCaseParameterName := strings.ToLower(capitalizedParameterName)
+		if !validator() {
+			s := ui.SelectFromOtherErrorMessage("Unknown "+lowerCaseParameterName, *parameterValue)
+			ui.Select(s, validValues)
+		} else {
+			ui.OutputSelection("Selected "+lowerCaseParameterName, *parameterValue)
+		}
+	}
+}
+
+func (o *createOptions) getCategories() []string {
+	// todo: implement operator querying of available capabilities
+	return []string{"database"}
+}
+
+func (o *createOptions) isValidCategory() bool {
+	return isValid(o.category, o.getCategories())
+}
+
+func isValid(value string, validValues []string) bool {
+	for _, v := range validValues {
+		if value == v {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *createOptions) getTypesFor(category string) []string {
+	// todo: implement operator querying for available types for given category
+	return []string{"postgres"}
+}
+
+func (o *createOptions) isValidTypeGivenCategory() bool {
+	return o.isValidTypeFor(o.category)
+}
+
+func (o *createOptions) isValidTypeFor(category string) bool {
+	return isValid(o.subCategory, o.getTypesFor(category))
+}
+
+func (o *createOptions) getVersionsFor(category, subCategory string) []string {
+	// todo: implement operator querying
+	return []string{"11", "10", "9.6", "9.5", "9.4"}
+}
+
+func (o *createOptions) isValidVersionFor(category, subCategory string) bool {
+	return isValid(o.version, o.getVersionsFor(category, subCategory))
+}
+
+func (o *createOptions) isValidVersionGivenCategoryAndType() bool {
+	return o.isValidVersionFor(o.category, o.subCategory)
+}
+
+func (o *createOptions) addToParams(pair string) error {
+	// todo: extract as generic version to be used for Envs and Parameters
+	split := strings.Split(pair, "=")
+	if len(split) != 2 {
+		return fmt.Errorf("invalid parameter: %s, format must be 'name=value'", pair)
+	}
+	parameter := halkyon.NameValuePair{Name: split[0], Value: split[1]}
+	o.parameters = append(o.parameters, parameter)
+	ui.OutputSelection("Set parameter", fmt.Sprintf("%s=%s", parameter.Name, parameter.Value))
+	return nil
+}
+
+func (o *createOptions) getParameterInfos() []parameterInfo {
+	// todo: implement operator querying
+	infos := make([]parameterInfo, 3, 3)
+	infos[0] = parameterInfo{
+		Validatable: validation.Validatable{
+			Required: true,
+			Type:     "string",
+		},
+		name: "DB_NAME",
+	}
+	infos[1] = parameterInfo{
+		name: "DB_PASSWORD",
+		Validatable: validation.Validatable{
+			Required: true,
+			Type:     "string",
+		},
+	}
+	infos[2] = parameterInfo{
+		name: "DB_USER",
+		Validatable: validation.Validatable{
+			Required: true,
+			Type:     "string",
+		},
+	}
+	return infos
+}
+
+func (o *createOptions) addValueFor(prop parameterInfo) {
+	var result string
+	prompt := &survey.Input{
+		Message: fmt.Sprintf("Enter a value for %s property %s:", prop.Type, prop.name),
+	}
+
+	err := survey.AskOne(prompt, &result, ui.GetValidatorFor(prop.AsValidatable()))
+	ui.HandleError(err)
+	o.parameters = append(o.parameters, halkyon.NameValuePair{
+		Name:  prop.name,
+		Value: result,
+	})
+}
+
+func NewCmdCreate(parent string) *cobra.Command {
+	o := &createOptions{}
+	capability := &cobra.Command{
+		Use:     fmt.Sprintf("%s [flags]", createCommandeName),
+		Short:   "Create a new capability",
+		Long:    `Create a new capability`,
+		Args:    cobra.NoArgs,
+		Example: fmt.Sprintf(capabilityExample, cmdutil.CommandName(createCommandeName, parent)),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.GenericRun(o, cmd, args)
+		},
+	}
+
+	capability.Flags().StringVarP(&o.category, "category", "g", "", "Capability category e.g. 'database'")
+	capability.Flags().StringVarP(&o.name, "name", "n", "", "Capability name")
+	capability.Flags().StringVarP(&o.subCategory, "type", "t", "", "Capability type e.g. 'postgres'")
+	capability.Flags().StringVarP(&o.version, "version", "v", "", "Capability version")
+	capability.Flags().StringSliceVarP(&o.paramPairs, "parameters", "p", []string{}, "Capability-specific parameters")
+
+	return capability
+}

--- a/pkg/hal/cli/capability/create.go
+++ b/pkg/hal/cli/capability/create.go
@@ -29,7 +29,7 @@ type createOptions struct {
 }
 
 var (
-	capabilityExample = ktemplates.Examples(`  # Create a new database capability de type postgres 10 and sets up some parameters as the name of the database and the user/password to connect.
+	capabilityExample = ktemplates.Examples(`  # Create a new database capability of type postgres 10 and sets up some parameters as the name of the database and the user/password to connect.
   %[1]s -n db-capability -g database -t postgres -v 10 -p DB_NAME=sample-db -p DB_PASSWORD=admin -p DB_USER=admin`)
 )
 

--- a/pkg/hal/cli/capability/delete.go
+++ b/pkg/hal/cli/capability/delete.go
@@ -1,0 +1,52 @@
+package capability
+
+import (
+	"github.com/spf13/cobra"
+	"halkyon.io/api/capability/clientset/versioned/typed/capability/v1beta1"
+	"halkyon.io/hal/pkg/cmdutil"
+	"halkyon.io/hal/pkg/k8s"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type client struct {
+	client v1beta1.CapabilityInterface
+	ns     string
+}
+
+func (lc client) Get(name string, options v1.GetOptions) error {
+	_, err := lc.client.Get(name, options)
+	return err
+}
+
+func (lc client) GetKnown() []string {
+	list, err := lc.client.List(v1.ListOptions{})
+	if err != nil {
+		return []string{}
+	}
+	items := list.Items
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+	return names
+}
+
+func (lc client) Delete(name string, options *v1.DeleteOptions) error {
+	return lc.client.Delete(name, options)
+}
+
+func (lc client) GetNamespace() string {
+	return lc.ns
+}
+
+func NewCmdDelete(fullParentName string) *cobra.Command {
+	c := k8s.GetClient()
+	generic := &cmdutil.DeleteOptions{
+		ResourceType: "capability",
+		Client: client{
+			client: c.HalkyonCapabilityClient.Capabilities(c.Namespace),
+			ns:     c.Namespace,
+		},
+	}
+	return cmdutil.NewGenericDelete(fullParentName, generic)
+}

--- a/pkg/hal/cli/component/common.go
+++ b/pkg/hal/cli/component/common.go
@@ -1,0 +1,69 @@
+package component
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	component "halkyon.io/api/component/v1beta1"
+	"halkyon.io/hal/pkg/cmdutil"
+	"halkyon.io/hal/pkg/k8s"
+	"halkyon.io/hal/pkg/log"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record/util"
+)
+
+type commonOptions struct {
+	*cmdutil.ComponentTargetingOptions
+}
+
+func (o *commonOptions) SetTargetingOptions(options *cmdutil.ComponentTargetingOptions) {
+	o.ComponentTargetingOptions = options
+}
+
+func (o *commonOptions) createIfNeeded() (*component.Component, error) {
+	c := k8s.GetClient()
+	name := o.GetTargetedComponentName()
+	comp, err := c.HalkyonComponentClient.Components(c.Namespace).Get(name, v1.GetOptions{})
+	if err != nil {
+		// check error to see if it means that the component doesn't exist yet
+		if util.IsKeyNotFoundError(errors.Cause(err)) {
+			// the component was not found so we need to create it first and wait for it to be ready
+			log.Infof("'%s' component was not found, initializing it", name)
+			err = k8s.Apply(o.GetTargetedComponentDescriptor(), c.Namespace)
+			if err != nil {
+				return nil, fmt.Errorf("error applying component CR: %v", err)
+			}
+
+			return o.waitUntilReady(comp)
+		} else {
+			return nil, err
+		}
+	}
+	return comp, nil
+}
+
+func (o *commonOptions) waitUntilReady(c *component.Component) (*component.Component, error) {
+	if component.ComponentReady == c.Status.Phase || component.ComponentRunning == c.Status.Phase {
+		return c, nil
+	}
+
+	name := o.GetTargetedComponentName()
+	client := k8s.GetClient()
+	cp, err := client.WaitForComponent(name, component.ComponentReady, "Waiting for component "+name+" to be ready…")
+	if err != nil {
+		return nil, fmt.Errorf("error waiting for component: %v", err)
+	}
+	err = errorIfFailedOrUnknown(c)
+	if err != nil {
+		return nil, err
+	}
+	return cp, nil
+}
+
+func errorIfFailedOrUnknown(c *component.Component) error {
+	switch c.Status.Phase {
+	case component.ComponentFailed, component.ComponentUnknown:
+		return errors.Errorf("status of component %s is %s: %s", c.Name, c.Status.Phase, c.Status.Message)
+	default:
+		return nil
+	}
+}

--- a/pkg/hal/cli/component/component.go
+++ b/pkg/hal/cli/component/component.go
@@ -13,18 +13,21 @@ func NewCmdComponent(parent string) *cobra.Command {
 	project := NewCmdProject(fullName)
 	push := NewCmdPush(fullName)
 	mode := NewCmdMode(fullName)
+	create := NewCmdCreate(fullName)
 
 	hal := &cobra.Command{
 		Use:   fmt.Sprintf("%s [flags]", commandName),
 		Short: "Manage components",
 		Long:  `Manage components`,
-		Example: fmt.Sprintf("%s\n\n%s\n\n%s",
+		Example: fmt.Sprintf("%s\n\n%s\n\n%s\n\n%s",
+			create.Example,
 			project.Example,
 			push.Example,
 			mode.Example),
 	}
 
 	hal.AddCommand(
+		create,
 		project,
 		push,
 		mode,

--- a/pkg/hal/cli/component/component.go
+++ b/pkg/hal/cli/component/component.go
@@ -14,13 +14,15 @@ func NewCmdComponent(parent string) *cobra.Command {
 	push := NewCmdPush(fullName)
 	mode := NewCmdMode(fullName)
 	create := NewCmdCreate(fullName)
+	del := NewCmdDelete(fullName)
 
 	hal := &cobra.Command{
 		Use:   fmt.Sprintf("%s [flags]", commandName),
 		Short: "Manage components",
 		Long:  `Manage components`,
-		Example: fmt.Sprintf("%s\n\n%s\n\n%s\n\n%s",
+		Example: fmt.Sprintf("%s\n\n%s\n\n%s\n\n%s\n\n%s",
 			create.Example,
+			del.Example,
 			project.Example,
 			push.Example,
 			mode.Example),
@@ -28,6 +30,7 @@ func NewCmdComponent(parent string) *cobra.Command {
 
 	hal.AddCommand(
 		create,
+		del,
 		project,
 		push,
 		mode,

--- a/pkg/hal/cli/component/create.go
+++ b/pkg/hal/cli/component/create.go
@@ -1,0 +1,48 @@
+package component
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"halkyon.io/hal/pkg/cmdutil"
+	"halkyon.io/hal/pkg/log"
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
+)
+
+const createCommandName = "create"
+
+type createOptions struct {
+	*commonOptions
+}
+
+var (
+	createExample = ktemplates.Examples(`  # Create a new Halkyon component found in the 'foo' child directory of the current directory
+  %[1]s -c foo`)
+)
+
+func (o *createOptions) Complete(name string, cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+func (o *createOptions) Validate() error {
+	return nil
+}
+
+func (o *createOptions) Run() error {
+	comp, err := o.createIfNeeded()
+	if err == nil {
+		log.Successf("Successfully created '%s' component", comp.Name)
+	}
+	return err
+}
+
+func NewCmdCreate(fullParentName string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     fmt.Sprintf("%s [flags]", createCommandName),
+		Short:   "Create a new Halkyon component",
+		Long:    `Create a new Halkyon component by sending a dekorate-generated Halkyon descriptor to the remote cluster you're connected to'`,
+		Example: fmt.Sprintf(createExample, cmdutil.CommandName(createCommandName, fullParentName)),
+		Args:    cobra.NoArgs,
+	}
+	cmdutil.ConfigureRunnableAndCommandWithTargeting(&createOptions{commonOptions: &commonOptions{}}, cmd)
+	return cmd
+}

--- a/pkg/hal/cli/component/create.go
+++ b/pkg/hal/cli/component/create.go
@@ -39,7 +39,7 @@ func NewCmdCreate(fullParentName string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     fmt.Sprintf("%s [flags]", createCommandName),
 		Short:   "Create a new Halkyon component",
-		Long:    `Create a new Halkyon component by sending a dekorate-generated Halkyon descriptor to the remote cluster you're connected to'`,
+		Long:    `Create a new Halkyon component by sending a dekorate-generated Halkyon descriptor to the remote cluster you're connected to`,
 		Example: fmt.Sprintf(createExample, cmdutil.CommandName(createCommandName, fullParentName)),
 		Args:    cobra.NoArgs,
 	}

--- a/pkg/hal/cli/component/delete.go
+++ b/pkg/hal/cli/component/delete.go
@@ -1,0 +1,52 @@
+package component
+
+import (
+	"github.com/spf13/cobra"
+	"halkyon.io/api/component/clientset/versioned/typed/component/v1beta1"
+	"halkyon.io/hal/pkg/cmdutil"
+	"halkyon.io/hal/pkg/k8s"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type client struct {
+	client v1beta1.ComponentInterface
+	ns     string
+}
+
+func (lc client) Get(name string, options v1.GetOptions) error {
+	_, err := lc.client.Get(name, options)
+	return err
+}
+
+func (lc client) GetKnown() []string {
+	list, err := lc.client.List(v1.ListOptions{})
+	if err != nil {
+		return []string{}
+	}
+	items := list.Items
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+	return names
+}
+
+func (lc client) Delete(name string, options *v1.DeleteOptions) error {
+	return lc.client.Delete(name, options)
+}
+
+func (lc client) GetNamespace() string {
+	return lc.ns
+}
+
+func NewCmdDelete(fullParentName string) *cobra.Command {
+	c := k8s.GetClient()
+	generic := &cmdutil.DeleteOptions{
+		ResourceType: "component",
+		Client: client{
+			client: c.HalkyonComponentClient.Components(c.Namespace),
+			ns:     c.Namespace,
+		},
+	}
+	return cmdutil.NewGenericDelete(fullParentName, generic)
+}

--- a/pkg/hal/cli/link/create.go
+++ b/pkg/hal/cli/link/create.go
@@ -1,0 +1,209 @@
+package link
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	link "halkyon.io/api/link/v1beta1"
+	halkyon "halkyon.io/api/v1beta1"
+	"halkyon.io/hal/pkg/cmdutil"
+	"halkyon.io/hal/pkg/k8s"
+	"halkyon.io/hal/pkg/log"
+	"halkyon.io/hal/pkg/ui"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+	"time"
+)
+
+const (
+	createCommandName = "create"
+	targetSeparator   = ": "
+)
+
+type createOptions struct {
+	targetName string
+	secret     string
+	name       string
+	envPairs   []string
+	envs       []halkyon.NameValuePair
+	linkType   link.LinkType
+}
+
+func (o *createOptions) Complete(name string, cmd *cobra.Command, args []string) error {
+	// first check if proper parameters combination are provided
+	useSecret := len(o.secret) > 0
+	useEnv := len(o.envPairs) > 0
+	if useSecret && useEnv {
+		return fmt.Errorf("invalid parameter combination: either pass a secret name or environment variables, not both")
+	}
+
+	// retrieve and build list of available targets
+	capabilitiesAndComponents, validTarget, err := o.checkAndGetValidTargets()
+	if err != nil {
+		return err
+	}
+	if len(capabilitiesAndComponents) == 0 {
+		return fmt.Errorf("no valid capabilities or components currently exist on the cluster")
+	}
+	if !validTarget {
+		o.targetName = o.extractTargetName(ui.Select("Target", capabilitiesAndComponents))
+	}
+
+	if !useSecret && !useEnv {
+		useSecret = ui.Proceed("Use Secret")
+	}
+
+	if useSecret {
+		o.linkType = link.SecretLinkType
+		ui.OutputSelection("Selected link type", o.linkType.String())
+		secrets, valid, err := o.checkAndGetValidSecrets()
+		if err != nil {
+			return err
+		}
+		if len(secrets) == 0 {
+			return fmt.Errorf("no valid secrets currently exist on the cluster")
+		}
+		if !valid {
+			o.secret = ui.Select("Secret", secrets)
+		}
+	} else {
+		o.linkType = link.EnvLinkType
+		ui.OutputSelection("Selected link type", o.linkType.String())
+		for _, pair := range o.envPairs {
+			if _, e := o.addToEnv(pair); e != nil {
+				return e
+			}
+		}
+		for {
+			envAsString := ui.AskOrReturnToExit("Env variable in the 'name=value' format, press enter when done")
+			if len(envAsString) == 0 {
+				break
+			}
+			if _, e := o.addToEnv(envAsString); e != nil {
+				return e
+			}
+		}
+	}
+
+	generated := fmt.Sprintf("%s-link-%d", o.targetName, time.Now().UnixNano())
+	o.name = ui.Ask("Change default name", o.name, generated)
+
+	return nil
+}
+
+func (o *createOptions) addToEnv(pair string) (halkyon.NameValuePair, error) {
+	// todo: extract as generic version
+	split := strings.Split(pair, "=")
+	if len(split) != 2 {
+		return halkyon.NameValuePair{}, fmt.Errorf("invalid environment variable: %s, format must be 'name=value'", pair)
+	}
+	env := halkyon.NameValuePair{Name: split[0], Value: split[1]}
+	o.envs = append(o.envs, env)
+	ui.OutputSelection("Set env variable", fmt.Sprintf("%s=%s", env.Name, env.Value))
+	return env, nil
+}
+
+func (o *createOptions) Validate() error {
+	// todo: validate selected link name
+	return nil
+}
+
+func (o *createOptions) Run() error {
+	client := k8s.GetClient()
+	l, err := client.HalkyonLinkClient.Links(client.Namespace).Create(&link.Link{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      o.name,
+			Namespace: client.Namespace,
+		},
+		Spec: link.LinkSpec{
+			ComponentName: o.targetName,
+			Type:          o.linkType,
+			Ref:           o.secret,
+			Envs:          o.envs,
+		},
+	})
+
+	if err != nil {
+		return err
+	}
+
+	log.Successf("Created link %s", l.Name)
+	// todo:
+	//  - read existing application.yml using viper
+	//  - merge existing and new link
+	//  - write updated application.yml
+	return nil
+}
+
+func NewCmdCreate(parent string) *cobra.Command {
+	o := &createOptions{}
+	l := &cobra.Command{
+		Use:     fmt.Sprintf("%s [flags]", createCommandName),
+		Short:   "Link the current (or target) component to the specified capability or component",
+		Long:    `Link the current (or target) component to the specified capability or component`,
+		Args:    cobra.NoArgs,
+		Example: fmt.Sprintf("  # links the client-sb to the backend-sb component\n %s -n client-to-backend -t client-sb", cmdutil.CommandName(createCommandName, parent)),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.GenericRun(o, cmd, args)
+		},
+	}
+	l.Flags().StringVarP(&o.targetName, "target", "t", "", "Name of the component or capability to link to")
+	l.Flags().StringVarP(&o.name, "name", "n", "", "Link name")
+	l.Flags().StringVarP(&o.secret, "secret", "s", "", "Secret name to reference if using Secret type")
+	l.Flags().StringSliceVarP(&o.envPairs, "env", "e", []string{}, "Environment variables as 'name=value' pairs")
+
+	return l
+}
+
+func (o *createOptions) checkAndGetValidTargets() ([]string, bool, error) {
+	const capabilityPrefix = "capability"
+	const componentPrefix = "component"
+	known := make([]string, 0, 10)
+	givenIsValid := false
+
+	client := k8s.GetClient()
+	capabilities, err := client.HalkyonCapabilityClient.Capabilities(client.Namespace).List(v1.ListOptions{})
+	if err != nil {
+		return nil, false, err
+	}
+	for _, c := range capabilities.Items {
+		known = append(known, fmt.Sprintf("%s%s%s", capabilityPrefix, targetSeparator, c.Name))
+		if !givenIsValid && c.Name == o.targetName {
+			givenIsValid = true
+		}
+	}
+
+	components, err := client.HalkyonComponentClient.Components(client.Namespace).List(v1.ListOptions{})
+	if err != nil {
+		return nil, false, err
+	}
+	for _, c := range components.Items {
+		known = append(known, fmt.Sprintf("%s%s%s", componentPrefix, targetSeparator, c.Name))
+		if !givenIsValid && c.Name == o.targetName {
+			givenIsValid = true
+		}
+	}
+
+	return known, givenIsValid, nil
+}
+
+func (createOptions) extractTargetName(typeAndTarget string) string {
+	index := strings.Index(typeAndTarget, targetSeparator)
+	return typeAndTarget[index+len(targetSeparator):]
+}
+
+func (o *createOptions) checkAndGetValidSecrets() ([]string, bool, error) {
+	client := k8s.GetClient()
+	secrets, err := client.KubeClient.CoreV1().Secrets(client.Namespace).List(v1.ListOptions{})
+	if err != nil {
+		return nil, false, err
+	}
+	known := make([]string, 0, len(secrets.Items))
+	givenIsValid := false
+	for _, secret := range secrets.Items {
+		known = append(known, secret.Name)
+		if secret.Name == o.secret {
+			givenIsValid = true
+		}
+	}
+	return known, givenIsValid, nil
+}

--- a/pkg/hal/cli/link/delete.go
+++ b/pkg/hal/cli/link/delete.go
@@ -1,0 +1,107 @@
+package link
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"halkyon.io/api/link/clientset/versioned/typed/link/v1beta1"
+	"halkyon.io/hal/pkg/cmdutil"
+	"halkyon.io/hal/pkg/k8s"
+	"halkyon.io/hal/pkg/log"
+	"halkyon.io/hal/pkg/ui"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record/util"
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
+)
+
+const deleteCommandName = "delete"
+
+type deleteOptions struct {
+	name   string
+	ns     string
+	client v1beta1.LinkInterface
+}
+
+var (
+	createExample = ktemplates.Examples(`  # Delete the link named 'foo'
+  %[1]s foo`)
+)
+
+func (o *deleteOptions) Complete(name string, cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		o.name = ""
+	} else {
+		o.name = args[0]
+	}
+	c := k8s.GetClient()
+	o.ns = c.Namespace
+	o.client = c.HalkyonLinkClient.Links(o.ns)
+	return nil
+}
+
+func (o *deleteOptions) Validate() error {
+	needLinkName := len(o.name) == 0
+	if !needLinkName {
+		_, err := o.client.Get(o.name, v1.GetOptions{})
+		if err != nil {
+			if util.IsKeyNotFoundError(errors.Cause(err)) {
+				needLinkName = true
+			} else {
+				return err
+			}
+		}
+	}
+	if needLinkName {
+		links := o.getKnownLinks()
+		if len(links) == 0 {
+			return fmt.Errorf("no link currently exist in '%s'", o.ns)
+		}
+		s := "Unknown link"
+		if len(o.name) == 0 {
+			s = "No provided link name"
+		}
+		message := ui.SelectFromOtherErrorMessage(s, o.name)
+		o.name = ui.Select(message, links)
+	}
+	return nil
+}
+
+func (o *deleteOptions) getKnownLinks() []string {
+	list, err := o.client.List(v1.ListOptions{})
+	if err != nil {
+		return []string{}
+	}
+	links := list.Items
+	names := make([]string, 0, len(links))
+	for _, link := range links {
+		names = append(names, link.Name)
+	}
+	return names
+}
+
+func (o *deleteOptions) Run() error {
+	if ui.Proceed(fmt.Sprintf("Really delete '%s' link", o.name)) {
+		err := o.client.Delete(o.name, &v1.DeleteOptions{})
+		if err == nil {
+			log.Successf("Successfully deleted '%s' link", o.name)
+		}
+		return err
+	}
+	log.Errorf("Canceled deletion of '%s' link", o.name)
+	return nil
+}
+
+func NewCmdDelete(fullParentName string) *cobra.Command {
+	o := &deleteOptions{}
+	cmd := &cobra.Command{
+		Use:     fmt.Sprintf("%s <name of link to delete>", deleteCommandName),
+		Short:   "Delete the named link",
+		Long:    `Delete the named link if it exists`,
+		Example: fmt.Sprintf(createExample, cmdutil.CommandName(deleteCommandName, fullParentName)),
+		Args:    cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.GenericRun(o, cmd, args)
+		},
+	}
+	return cmd
+}

--- a/pkg/hal/cli/link/delete.go
+++ b/pkg/hal/cli/link/delete.go
@@ -1,107 +1,52 @@
 package link
 
 import (
-	"fmt"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"halkyon.io/api/link/clientset/versioned/typed/link/v1beta1"
 	"halkyon.io/hal/pkg/cmdutil"
 	"halkyon.io/hal/pkg/k8s"
-	"halkyon.io/hal/pkg/log"
-	"halkyon.io/hal/pkg/ui"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/record/util"
-	ktemplates "k8s.io/kubectl/pkg/util/templates"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const deleteCommandName = "delete"
-
-type deleteOptions struct {
-	name   string
-	ns     string
+type client struct {
 	client v1beta1.LinkInterface
+	ns     string
 }
 
-var (
-	createExample = ktemplates.Examples(`  # Delete the link named 'foo'
-  %[1]s foo`)
-)
-
-func (o *deleteOptions) Complete(name string, cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		o.name = ""
-	} else {
-		o.name = args[0]
-	}
-	c := k8s.GetClient()
-	o.ns = c.Namespace
-	o.client = c.HalkyonLinkClient.Links(o.ns)
-	return nil
+func (lc client) Get(name string, options v1.GetOptions) error {
+	_, err := lc.client.Get(name, options)
+	return err
 }
 
-func (o *deleteOptions) Validate() error {
-	needLinkName := len(o.name) == 0
-	if !needLinkName {
-		_, err := o.client.Get(o.name, v1.GetOptions{})
-		if err != nil {
-			if util.IsKeyNotFoundError(errors.Cause(err)) {
-				needLinkName = true
-			} else {
-				return err
-			}
-		}
-	}
-	if needLinkName {
-		links := o.getKnownLinks()
-		if len(links) == 0 {
-			return fmt.Errorf("no link currently exist in '%s'", o.ns)
-		}
-		s := "Unknown link"
-		if len(o.name) == 0 {
-			s = "No provided link name"
-		}
-		message := ui.SelectFromOtherErrorMessage(s, o.name)
-		o.name = ui.Select(message, links)
-	}
-	return nil
-}
-
-func (o *deleteOptions) getKnownLinks() []string {
-	list, err := o.client.List(v1.ListOptions{})
+func (lc client) GetKnown() []string {
+	list, err := lc.client.List(v1.ListOptions{})
 	if err != nil {
 		return []string{}
 	}
-	links := list.Items
-	names := make([]string, 0, len(links))
-	for _, link := range links {
-		names = append(names, link.Name)
+	items := list.Items
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
 	}
 	return names
 }
 
-func (o *deleteOptions) Run() error {
-	if ui.Proceed(fmt.Sprintf("Really delete '%s' link", o.name)) {
-		err := o.client.Delete(o.name, &v1.DeleteOptions{})
-		if err == nil {
-			log.Successf("Successfully deleted '%s' link", o.name)
-		}
-		return err
-	}
-	log.Errorf("Canceled deletion of '%s' link", o.name)
-	return nil
+func (lc client) Delete(name string, options *v1.DeleteOptions) error {
+	return lc.client.Delete(name, options)
+}
+
+func (lc client) GetNamespace() string {
+	return lc.ns
 }
 
 func NewCmdDelete(fullParentName string) *cobra.Command {
-	o := &deleteOptions{}
-	cmd := &cobra.Command{
-		Use:     fmt.Sprintf("%s <name of link to delete>", deleteCommandName),
-		Short:   "Delete the named link",
-		Long:    `Delete the named link if it exists`,
-		Example: fmt.Sprintf(createExample, cmdutil.CommandName(deleteCommandName, fullParentName)),
-		Args:    cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.GenericRun(o, cmd, args)
+	c := k8s.GetClient()
+	generic := &cmdutil.DeleteOptions{
+		ResourceType: "link",
+		Client: client{
+			client: c.HalkyonLinkClient.Links(c.Namespace),
+			ns:     c.Namespace,
 		},
 	}
-	return cmd
+	return cmdutil.NewGenericDelete(fullParentName, generic)
 }

--- a/pkg/hal/cli/link/link.go
+++ b/pkg/hal/cli/link/link.go
@@ -3,207 +3,24 @@ package link
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	link "halkyon.io/api/link/v1beta1"
-	halkyon "halkyon.io/api/v1beta1"
 	"halkyon.io/hal/pkg/cmdutil"
-	"halkyon.io/hal/pkg/k8s"
-	"halkyon.io/hal/pkg/log"
-	"halkyon.io/hal/pkg/ui"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
-	"time"
 )
 
 const (
-	commandName     = "link"
-	targetSeparator = ": "
+	commandName = "link"
 )
 
-type options struct {
-	targetName string
-	secret     string
-	name       string
-	envPairs   []string
-	envs       []halkyon.NameValuePair
-	linkType   link.LinkType
-}
-
-func (o *options) Complete(name string, cmd *cobra.Command, args []string) error {
-	// first check if proper parameters combination are provided
-	useSecret := len(o.secret) > 0
-	useEnv := len(o.envPairs) > 0
-	if useSecret && useEnv {
-		return fmt.Errorf("invalid parameter combination: either pass a secret name or environment variables, not both")
-	}
-
-	// retrieve and build list of available targets
-	capabilitiesAndComponents, validTarget, err := o.checkAndGetValidTargets()
-	if err != nil {
-		return err
-	}
-	if len(capabilitiesAndComponents) == 0 {
-		return fmt.Errorf("no valid capabilities or components currently exist on the cluster")
-	}
-	if !validTarget {
-		o.targetName = o.extractTargetName(ui.Select("Target", capabilitiesAndComponents))
-	}
-
-	if !useSecret && !useEnv {
-		useSecret = ui.Proceed("Use Secret")
-	}
-
-	if useSecret {
-		o.linkType = link.SecretLinkType
-		ui.OutputSelection("Selected link type", o.linkType.String())
-		secrets, valid, err := o.checkAndGetValidSecrets()
-		if err != nil {
-			return err
-		}
-		if len(secrets) == 0 {
-			return fmt.Errorf("no valid secrets currently exist on the cluster")
-		}
-		if !valid {
-			o.secret = ui.Select("Secret", secrets)
-		}
-	} else {
-		o.linkType = link.EnvLinkType
-		ui.OutputSelection("Selected link type", o.linkType.String())
-		for _, pair := range o.envPairs {
-			if _, e := o.addToEnv(pair); e != nil {
-				return e
-			}
-		}
-		for {
-			envAsString := ui.AskOrReturnToExit("Env variable in the 'name=value' format, press enter when done")
-			if len(envAsString) == 0 {
-				break
-			}
-			if _, e := o.addToEnv(envAsString); e != nil {
-				return e
-			}
-		}
-	}
-
-	generated := fmt.Sprintf("%s-link-%d", o.targetName, time.Now().UnixNano())
-	o.name = ui.Ask("Change default name", o.name, generated)
-
-	return nil
-}
-
-func (o *options) addToEnv(pair string) (halkyon.NameValuePair, error) {
-	// todo: extract as generic version
-	split := strings.Split(pair, "=")
-	if len(split) != 2 {
-		return halkyon.NameValuePair{}, fmt.Errorf("invalid environment variable: %s, format must be 'name=value'", pair)
-	}
-	env := halkyon.NameValuePair{Name: split[0], Value: split[1]}
-	o.envs = append(o.envs, env)
-	ui.OutputSelection("Set env variable", fmt.Sprintf("%s=%s", env.Name, env.Value))
-	return env, nil
-}
-
-func (o *options) Validate() error {
-	// todo: validate selected link name
-	return nil
-}
-
-func (o *options) Run() error {
-	client := k8s.GetClient()
-	l, err := client.HalkyonLinkClient.Links(client.Namespace).Create(&link.Link{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      o.name,
-			Namespace: client.Namespace,
-		},
-		Spec: link.LinkSpec{
-			ComponentName: o.targetName,
-			Type:          o.linkType,
-			Ref:           o.secret,
-			Envs:          o.envs,
-		},
-	})
-
-	if err != nil {
-		return err
-	}
-
-	log.Successf("Created link %s", l.Name)
-	// todo:
-	//  - read existing application.yml using viper
-	//  - merge existing and new link
-	//  - write updated application.yml
-	return nil
-}
-
 func NewCmdLink(parent string) *cobra.Command {
-	o := &options{}
+	create := NewCmdCreate(cmdutil.CommandName(commandName, parent))
 	l := &cobra.Command{
 		Use:     fmt.Sprintf("%s [flags]", commandName),
-		Short:   "Link the current (or target) component to the specified capability or component",
-		Long:    `Link the current (or target) component to the specified capability or component`,
+		Short:   "Manage links",
+		Long:    `Manage links`,
 		Args:    cobra.NoArgs,
-		Example: fmt.Sprintf("  # links the client-sb to the backend-sb component\n %s -n client-to-backend -t client-sb", cmdutil.CommandName(commandName, parent)),
-		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.GenericRun(o, cmd, args)
-		},
+		Example: fmt.Sprintf("%s", create.Example),
 	}
-	l.Flags().StringVarP(&o.targetName, "target", "t", "", "Name of the component or capability to link to")
-	l.Flags().StringVarP(&o.name, "name", "n", "", "Link name")
-	l.Flags().StringVarP(&o.secret, "secret", "s", "", "Secret name to reference if using Secret type")
-	l.Flags().StringSliceVarP(&o.envPairs, "env", "e", []string{}, "Environment variables as 'name=value' pairs")
+
+	l.AddCommand(create)
 
 	return l
-}
-
-func (o *options) checkAndGetValidTargets() ([]string, bool, error) {
-	const capabilityPrefix = "capability"
-	const componentPrefix = "component"
-	known := make([]string, 0, 10)
-	givenIsValid := false
-
-	client := k8s.GetClient()
-	capabilities, err := client.HalkyonCapabilityClient.Capabilities(client.Namespace).List(v1.ListOptions{})
-	if err != nil {
-		return nil, false, err
-	}
-	for _, c := range capabilities.Items {
-		known = append(known, fmt.Sprintf("%s%s%s", capabilityPrefix, targetSeparator, c.Name))
-		if !givenIsValid && c.Name == o.targetName {
-			givenIsValid = true
-		}
-	}
-
-	components, err := client.HalkyonComponentClient.Components(client.Namespace).List(v1.ListOptions{})
-	if err != nil {
-		return nil, false, err
-	}
-	for _, c := range components.Items {
-		known = append(known, fmt.Sprintf("%s%s%s", componentPrefix, targetSeparator, c.Name))
-		if !givenIsValid && c.Name == o.targetName {
-			givenIsValid = true
-		}
-	}
-
-	return known, givenIsValid, nil
-}
-
-func (options) extractTargetName(typeAndTarget string) string {
-	index := strings.Index(typeAndTarget, targetSeparator)
-	return typeAndTarget[index+len(targetSeparator):]
-}
-
-func (o *options) checkAndGetValidSecrets() ([]string, bool, error) {
-	client := k8s.GetClient()
-	secrets, err := client.KubeClient.CoreV1().Secrets(client.Namespace).List(v1.ListOptions{})
-	if err != nil {
-		return nil, false, err
-	}
-	known := make([]string, 0, len(secrets.Items))
-	givenIsValid := false
-	for _, secret := range secrets.Items {
-		known = append(known, secret.Name)
-		if secret.Name == o.secret {
-			givenIsValid = true
-		}
-	}
-	return known, givenIsValid, nil
 }

--- a/pkg/hal/cli/link/link.go
+++ b/pkg/hal/cli/link/link.go
@@ -11,16 +11,22 @@ const (
 )
 
 func NewCmdLink(parent string) *cobra.Command {
-	create := NewCmdCreate(cmdutil.CommandName(commandName, parent))
+	fullName := cmdutil.CommandName(commandName, parent)
+	create := NewCmdCreate(fullName)
+	del := NewCmdDelete(fullName)
 	l := &cobra.Command{
-		Use:     fmt.Sprintf("%s [flags]", commandName),
-		Short:   "Manage links",
-		Long:    `Manage links`,
-		Args:    cobra.NoArgs,
-		Example: fmt.Sprintf("%s", create.Example),
+		Use:   fmt.Sprintf("%s [flags]", commandName),
+		Short: "Manage links",
+		Long:  `Manage links`,
+		Args:  cobra.NoArgs,
+		Example: fmt.Sprintf("%s\n\n%s",
+			create.Example, del.Example),
 	}
 
-	l.AddCommand(create)
+	l.AddCommand(
+		create,
+		del,
+	)
 
 	return l
 }


### PR DESCRIPTION
Re-organized commands so that things are coherent:
- `hal component push` has been split back into `hal component create` and `hal component push` which only does the push now
- `hal link` becomes `hal link create`
- `hal capability` becomes `hal capability create`