### PR TITLE
fix: upload binaries to `/deployments/`

### DIFF
--- a/pkg/k8s/kubectl.go
+++ b/pkg/k8s/kubectl.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	JarPathInContainer             = "/usr/src/target/"
+	JarPathInContainer             = "/deployments/"
 	SourcePathInContainer          = "/usr/component.tar"
 	ExtractedSourcePathInContainer = "/usr/src"
 )


### PR DESCRIPTION
This change is meant to follow changes to how the maven image
works: builds from source are now copied to /deployments
since it was possible a binary upload would fail if no source
build had been performed.