### PR TITLE
Update micro of Vert.x 3.8 to 3.8.4

### DIFF
--- a/pkg/hal/cli/component/create.go
+++ b/pkg/hal/cli/component/create.go
@@ -35,7 +35,7 @@ var runtimes = map[string]halkyonRuntime{
 	},
 	"vert.x": {
 		name:      "vert.x",
-		versions:  []string{"3.8.3", "3.7.1"},
+		versions:  []string{"3.8.4", "3.7.1"},
 		generator: `https://start.vertx.io/starter.zip?vertxVersion={{.RV}}&groupId={{.G}}&artifactId={{.A}}&packageName={{.P}}`,
 	},
 	"thorntail": {


### PR DESCRIPTION
start.vert.io only supports the latest micro release of any minor version.  Given this, 3.8.3 is no longer supported so the version needs to be bumped to 3.8.4